### PR TITLE
SwiftyJSON 4.0 compatibility

### DIFF
--- a/Sources/ResponseProtocol.swift
+++ b/Sources/ResponseProtocol.swift
@@ -168,7 +168,7 @@ public class Response: ResponseProtocol {
 	}
 	
 	private lazy var cachedJSON: JSON = {
-		return JSON(data: self.data ?? Data())
+		return try! JSON(data: self.data ?? Data())
 	}()
 	
 }


### PR DESCRIPTION
With the release of SwiftyJSON 4.0, the init method throws an exception if the data couldn't be parsed into a valid JSON.  `try` can be banged since cache is valid or an empty `Data`object is passed as argument.