### PR TITLE
Cleanup, migration and fixes

### DIFF
--- a/HermesNetwork.xcodeproj/project.pbxproj
+++ b/HermesNetwork.xcodeproj/project.pbxproj
@@ -365,11 +365,11 @@
 				TargetAttributes = {
 					52D6D97B1BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 					52D6D9851BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1000;
 					};
 					52D6D9E11BEFFF6E002C0205 = {
 						CreatedOnToolsVersion = 7.1;
@@ -656,7 +656,7 @@
 				PRODUCT_NAME = HermesNetwork;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -678,7 +678,7 @@
 				PRODUCT_NAME = HermesNetwork;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -691,7 +691,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.HermesNetwork.HermesNetwork-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -704,7 +704,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.HermesNetwork.HermesNetwork-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Sources/Extension.swift
+++ b/Sources/Extension.swift
@@ -36,7 +36,7 @@ public extension Dictionary where Key == String, Value == Any? {
 	/// - Throws: throw `.dataIsNotEncodable` if data cannot be encoded
 	public func urlEncodedString(base: String = "") throws -> String {
 		guard self.count > 0 else { return "" } // nothing to encode
-		let items: [URLQueryItem] = self.flatMap { (key,value) in
+		let items: [URLQueryItem] = self.compactMap { (key,value) in
 			guard let v = value else { return nil } // skip item if no value is set
 			return URLQueryItem(name: key, value: String(describing: v))
 		}

--- a/Sources/ResponseProtocol.swift
+++ b/Sources/ResponseProtocol.swift
@@ -159,7 +159,7 @@ public class Response: ResponseProtocol {
 	}
 	
 	public func toJSON() -> JSON {
-		return self.cachedJSON
+		return self.cachedJSON ?? JSON()
 	}
 	
 	public func toString(_ encoding: String.Encoding? = nil) -> String? {
@@ -167,8 +167,8 @@ public class Response: ResponseProtocol {
 		return String(data: d, encoding: encoding ?? .utf8)
 	}
 	
-	private lazy var cachedJSON: JSON = {
-		return JSON(data: self.data ?? Data())
+	private lazy var cachedJSON: JSON? = {
+		return try? JSON(data: self.data ?? Data())
 	}()
 	
 }


### PR DESCRIPTION
This PR

- Migrates the project to Swift 4.2
- Switches to `compactMap` from the deprecated `flatMap`
- Handles error in SwiftyJSON while trying to convert response data into JSON